### PR TITLE
Add action to automatically merge Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,16 @@
+# This workflow automatically merges dependabot PRs
+
+name: Automerge Dependabot PRs
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
**Description**

This repo should be the place for shared actions, right? 

- When this is merged, we should test from one of the plugins if inheriting works
- If that succeeds, we can also update swup's dependabot-automerge action

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
