### PR TITLE
Add `workflow_call` to dependabot automerge action

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -3,7 +3,7 @@
 name: Automerge Dependabot PRs
 
 on:
-  pull_request:
+  workflow_call:
 
 jobs:
   auto-merge:


### PR DESCRIPTION
**Description**

Add `workflow_call` to the dependabot-automerge action, so that it can be used from our other packages

**Checks**

<!--
Make sure the PR fulfills as many of the following requirements as possible
-->

- [x] The PR is submitted to the `master` branch
- [x] The code was linted before pushing (`npm run lint`)
